### PR TITLE
Issue#4

### DIFF
--- a/MODULE_README.md
+++ b/MODULE_README.md
@@ -1,12 +1,12 @@
-# Zzz.js [![Build Status](https://travis-ci.org/uupaa/Zzz.js.png)](http://travis-ci.org/uupaa/Zzz.js)
+# Zzz.js [![Build Status](https://travis-ci.org/__GITHUB_USER_NAME__/Zzz.js.png)](http://travis-ci.org/__GITHUB_USER_NAME__/Zzz.js)
 
-[![npm](https://nodei.co/npm/uupaa.zzz.js.png?downloads=true&stars=true)](https://nodei.co/npm/uupaa.zzz.js/)
+[![npm](https://nodei.co/npm/__GITHUB_USER_NAME__.zzz.js.png?downloads=true&stars=true)](https://nodei.co/npm/__GITHUB_USER_NAME__.zzz.js/)
 
 Zzz.js description.
 
 ## Document
 
-- [Zzz.js wiki](https://github.com/uupaa/Zzz.js/wiki/Zzz)
+- [Zzz.js wiki](https://github.com/__GITHUB_USER_NAME__/Zzz.js/wiki/Zzz)
 - [Development](https://github.com/uupaa/WebModule/wiki/Development)
 - [WebModule](https://github.com/uupaa/WebModule) ([Slide](http://uupaa.github.io/Slide/slide/WebModule/index.html))
 

--- a/clone
+++ b/clone
@@ -220,12 +220,7 @@ function _doClone(overwriteFiles, fromDir, toDir, fileTree) {
             text = text.replace(/webmodule/, (githubUserName + "." + repositoryFullName).toLowerCase());
             text = text.replace(/\"version\"\:(\s*)\"[^"]*\"/, "\"version\":$1\"0.0.0\"");
         }
-        /*
-        if (fileName === "README.md") {
-            text = text.replace(/webmodule/, (githubUserName + "." + repositoryFullName).toLowerCase());
-            text = text.replace(/\"version\"\:(\s*)\"[^"]*\"/, "\"version\":$1\"0.0.0\"");
-        }*/
-
+        
         // Replace zzz to repository name.
         text = text.replace(/Zzz/g, repositoryName).
                     replace(/zzz/g, repositoryName.toLowerCase());

--- a/clone
+++ b/clone
@@ -220,7 +220,7 @@ function _doClone(overwriteFiles, fromDir, toDir, fileTree) {
             text = text.replace(/webmodule/, (githubUserName + "." + repositoryFullName).toLowerCase());
             text = text.replace(/\"version\"\:(\s*)\"[^"]*\"/, "\"version\":$1\"0.0.0\"");
         }
-        
+
         // Replace zzz to repository name.
         text = text.replace(/Zzz/g, repositoryName).
                     replace(/zzz/g, repositoryName.toLowerCase());

--- a/clone
+++ b/clone
@@ -220,17 +220,20 @@ function _doClone(overwriteFiles, fromDir, toDir, fileTree) {
             text = text.replace(/webmodule/, (githubUserName + "." + repositoryFullName).toLowerCase());
             text = text.replace(/\"version\"\:(\s*)\"[^"]*\"/, "\"version\":$1\"0.0.0\"");
         }
+        /*
+        if (fileName === "README.md") {
+            text = text.replace(/webmodule/, (githubUserName + "." + repositoryFullName).toLowerCase());
+            text = text.replace(/\"version\"\:(\s*)\"[^"]*\"/, "\"version\":$1\"0.0.0\"");
+        }*/
 
         // Replace zzz to repository name.
         text = text.replace(/Zzz/g, repositoryName).
                     replace(/zzz/g, repositoryName.toLowerCase());
 
         // Replace GitHub UserName.
-        //      "github.com/uupaa" -> "github.com/githubUserName"
+        //      "__GITHUB_USER_NAME__" -> "githubUserName"
         if (githubUserName) {
-            text = text.replace(/github.com(.)uupaa/g, function(_, sep) {
-                return "github.com" + sep + githubUserName;
-            });
+            text = text.replace(/__GITHUB_USER_NAME__/g, githubUserName);
         }
         return text;
     }

--- a/lib/Zzz.js
+++ b/lib/Zzz.js
@@ -18,7 +18,7 @@ function Zzz(value) { // @arg Number|Integer = 0 comment
 }
 
 //{@dev
-Zzz["repository"] = "https://github.com/uupaa/Zzz.js"; // GitHub repository URL. http://git.io/Help
+Zzz["repository"] = "https://github.com/__GITHUB_USER_NAME__/Zzz.js"; // GitHub repository URL. http://git.io/Help
 //}@dev
 
 Zzz["prototype"]["value"]     = Zzz_value;     // Zzz#value():Number|Integer = 0
@@ -63,4 +63,3 @@ if ("process" in global) {
 global["Zzz" in global ? "Zzz_" : "Zzz"] = Zzz; // switch module. http://git.io/Minify
 
 })((this || 0).self || global); // WebModule idiom. http://git.io/WebModule
-

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name":           "webmodule",
   "version":        "0.0.36",
   "description":    "Module template for Mobile Web Application.",
-  "url":            "https://github.com/uupaa/Zzz.js",
+  "url":            "https://github.com/__GITHUB_USER_NAME__/Zzz.js",
   "keywords":       ["WebModule", "Unstable"],
   "repository": {
     "type":         "git",
-    "url":          "https://github.com/uupaa/Zzz.js.git"
+    "url":          "https://github.com/__GITHUB_USER_NAME__/Zzz.js.git"
   },
   "scripts": {
     "watch":        "node node_modules/uupaa.watch.js --verbose --action build",
@@ -52,7 +52,7 @@
   },
   "lib":            "./lib/",
   "main":           "./index.js",
-  "author":         "uupaa <uupaa.js@gmail.com>",
+  "author":         "__GITHUB_USER_NAME__ <__GITHUB_USER_NAME__.js@gmail.com>",
   "license":        "MIT",
   "contributors":   []
 }


### PR DESCRIPTION
https://github.com/uupaa/WebModule/issues/4

この問題に関する提案です。

現行の方式では`/github.com(.)uupaa/`の`uupaa`を置換していました。
しかしこの方法では、先のissue#4に挙げたような問題が発生していました。

``` js
text = text.replace(/github.com(.)uupaa/g, function(_, sep) {
  return "github.com" + sep + githubUserName;
});
```

そこで、置換対象を`__GITHUB_USER_NAME__`というマクロ変数を利用して問題の解決を試みます。

``` js
text = text.replace(/github.com(.)uupaa/g, function(_, sep) {
  return "github.com" + sep + githubUserName;
});
```

この方式も「マクロ変数名を`__HOGE__`という安易な形にして良いのか」等、問題があります。

ひとつの提案としてご査収ください。
