### PR TITLE
WebModule Idiom Version2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+lib/WebModuleGlobal.js
+

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,26 @@
+{
+    "env": {
+        "browser":          true,
+        "node":             true
+    },
+    "globals": {
+        "IN_NODE_OR_NW":    false,
+        "IN_BROWSER":       false,
+        "IN_WORKER":        false,
+        "IN_NODE":          false,
+        "IN_NW":            false
+    },
+    "rules": {
+        "strict":           [0],
+        "new-cap":          [0],
+        "camelcase":        [0],
+        "key-spacing":      [0],
+        "dot-notation":     [0],
+        "comma-dangle":     [0],
+        "no-multi-spaces":  [0],
+        "no-unused-vars":   [1, { "vars": "all", "args": "after-used"} ],
+        "no-underscore-dangle": [0],
+        "no-use-before-define": [0]
+    }
+}
+

--- a/MODULE_package.json
+++ b/MODULE_package.json
@@ -20,7 +20,7 @@
     "browser":      "open http://localhost:8000/REPOSITORY_FULLNAME/test/index.html",
     "sim":          "node ../WebModule/run/sim.js http://localhost:8000/REPOSITORY_FULLNAME/test/index.html",
     "simx":         "node ../WebModule/run/sim.js stop",
-    "hint":         "jshint lib/*.js",
+    "hint":         "eslint lib/*.js",
     "score":        "node ../WebModule/run/score.js; open lint/plato/index.html",
     "patch":        "node ../WebModule/run/patch.js",
     "setup":        "node ../WebModule/run/setup.js",
@@ -47,7 +47,9 @@
       "output":     "release/REPOSITORY_NAME.nw.min.js"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "uupaa.hash.js": ""
+  },
   "devDependencies": {},
   "lib":            "./lib/",
   "main":           "./index.js",

--- a/lib/REPOSITORY_NAME.js
+++ b/lib/REPOSITORY_NAME.js
@@ -1,14 +1,25 @@
-(function(global) {
+// --- WebModule idiom v2 - http://git.io/WebModule --------
+
+(function moduleExporter(moduleName, moduleBody) {
+   "use strict";
+
+    var alias  = moduleName in GLOBAL ? (moduleName + "_") : moduleName; // switch module. http://git.io/Minify
+    var entity = moduleBody();
+
+    if (typeof modules !== "undefined") {
+        GLOBAL["modules"]["register"](alias, moduleBody, entity["repository"]);
+    }
+    if (typeof exports !== "undefined") {
+        module["exports"] = entity;
+    }
+    GLOBAL[alias] = entity;
+
+})("REPOSITORY_NAME", function moduleBody() {
+
 "use strict";
 
-// --- dependency modules ----------------------------------
-// --- define / local variables ----------------------------
-//var _isNodeOrNodeWebKit = !!global.global;
-//var _runOnNodeWebKit =  _isNodeOrNodeWebKit &&  /native/.test(setTimeout);
-//var _runOnNode       =  _isNodeOrNodeWebKit && !/native/.test(setTimeout);
-//var _runOnWorker     = !_isNodeOrNodeWebKit && "WorkerLocation" in global;
-//var _runOnBrowser    = !_isNodeOrNodeWebKit && "document" in global;
-
+// --- dependency modules (optional) -----------------------
+// --- define / local variables (optional) -----------------
 // --- class / interfaces ----------------------------------
 function REPOSITORY_NAME(value) { // @arg String = "" - comment
 //{@dev
@@ -60,20 +71,7 @@ function REPOSITORY_NAME_concat$(a) { // @arg String
     return this;
 }
 
-// --- validate / assertions -------------------------------
-//{@dev
-//function $valid(val, fn, hint) { if (global["Valid"]) { global["Valid"](val, fn, hint); } }
-//function $type(obj, type) { return global["Valid"] ? global["Valid"].type(obj, type) : true; }
-//function $keys(obj, str) { return global["Valid"] ? global["Valid"].keys(obj, str) : true; }
-//function $some(val, str, ignore) { return global["Valid"] ? global["Valid"].some(val, str, ignore) : true; }
-//function $args(fn, args) { if (global["Valid"]) { global["Valid"].args(fn, args); } }
-//}@dev
+return REPOSITORY_NAME; // return ModuleEntity
 
-// --- exports ---------------------------------------------
-if (typeof module !== "undefined") {
-    module["exports"] = REPOSITORY_NAME;
-}
-global["REPOSITORY_NAME" in global ? "REPOSITORY_NAME_" : "REPOSITORY_NAME"] = REPOSITORY_NAME; // switch module. http://git.io/Minify
-
-})(WEBMODULE_IDIOM); // WebModule idiom. http://git.io/WebModule
+});
 

--- a/lib/WebModuleGlobal.js
+++ b/lib/WebModuleGlobal.js
@@ -1,0 +1,54 @@
+// --- WebModule idiom v2 - http://git.io/WebModule --------
+// --- environment detection -------------------------------
+var GLOBAL          = GLOBAL || (this || 0).self || global;
+var IN_NODE_OR_NW   = !!GLOBAL.global;
+var IN_BROWSER      = !IN_NODE_OR_NW && "document" in GLOBAL;
+var IN_WORKER       = !IN_NODE_OR_NW && "WorkerLocation" in GLOBAL;
+var IN_NODE         =  IN_NODE_OR_NW && !/native/.test(setTimeout);
+var IN_NW           =  IN_NODE_OR_NW &&  /native/.test(setTimeout);
+
+// --- validate and assert functions (optional) ------------
+function $type(obj, type)      { return GLOBAL["Valid"] ? GLOBAL["Valid"].type(obj, type)    : true; }
+function $keys(obj, str)       { return GLOBAL["Valid"] ? GLOBAL["Valid"].keys(obj, str)     : true; }
+function $some(val, str, ig)   { return GLOBAL["Valid"] ? GLOBAL["Valid"].some(val, str, ig) : true; }
+function $args(fn, args)       { if (GLOBAL["Valid"]) { GLOBAL["Valid"].args(fn, args); } }
+function $valid(val, fn, hint) { if (GLOBAL["Valid"]) { GLOBAL["Valid"](val, fn, hint); } }
+
+// --- WebModules ------------------------------------------
+function WebModules() {
+    this._modules = {}; // { name: { body, hash, repository, size }, ... }
+}
+
+WebModules["VERBOSE"] = false;
+WebModules.prototype.register = function(name,         // @arg ModuleNameString
+                                         body,         // @arg Function|String
+                                         repository) { // @arg String = ""
+    var moduleBody = typeof body === "function" ? body + "" : body;
+    var hash = 0;
+
+    if (typeof Hash !== "undefined") {
+        hash = GLOBAL["Hash"]["XXHash"](moduleBody);
+    }
+    if ( !(name in this._modules) ) {
+        if (WebModules["VERBOSE"]) {
+            console.log("WebModules#register: " + name);
+        }
+
+        this._modules[name] = {
+            "body": moduleBody,
+            "size": moduleBody.length,
+            "hash": hash,
+            "repository": repository || ""
+        };
+    }
+};
+
+WebModules.prototype.dump = function() {
+    for (var name in this._modules) {
+        console.log(name, this._modules[name]["hash"]);
+    }
+};
+
+var modules = new WebModules();
+
+

--- a/run/minify.js
+++ b/run/minify.js
@@ -418,7 +418,8 @@ function _makeClouserCompilerOptions(options) { // @arg Object - { keep, nowrap,
         result.push("--compilation_level SIMPLE_OPTIMIZATIONS");
     }
     if (!options.nowrap) { // wrap WebModule idiom
-        result.push("--output_wrapper '(function(global){\n%output%\n})((this||0).self||global);'");
+      //result.push("--output_wrapper '(function(global){\n%output%\n})((this||0).self||global);'");
+        result.push("--output_wrapper '(function(global){\n%output%\n})(GLOBAL);'"); // WebModule Idiom v2
     }
 
     if (options.strict) {
@@ -547,23 +548,6 @@ function _trimCodeBlock(js,       // @arg String - JavaScript expression string.
         // }@label
         //
         var lines = RegExp("\\{@" + label + "\\b(?:[^\\n]*)\n(?:[\\S\\s]*?)?\\}@" +
-                                    label + "\\b", "g");
-
-
-        // trim:
-        //
-        // [@label ... ]@label
-        //
-        var line  = RegExp("\\[@" + label + "\\b(?:[^\\n]*)\\]@" +
-                                    label + "\\b", "g");
-
-        // trim:
-        //
-        // [@label
-        //   ...
-        // ]@label
-        //
-        var lines = RegExp("\\[@" + label + "\\b(?:[^\\n]*)\n(?:[\\S\\s]*?)?\\]@" +
                                     label + "\\b", "g");
 
 

--- a/run/setup.js
+++ b/run/setup.js
@@ -26,6 +26,7 @@ var _CLONE_FILES = {
 //      "REPOSITORY_NAME.js":   [true],
 //  },
     "lib": {
+        "WebModuleGlobal.js":   [true],
         "REPOSITORY_NAME.js":   [true],
     },
     "lint": {
@@ -47,7 +48,9 @@ var _CLONE_FILES = {
         "testcase.js":          [true],
     },
     ".gitignore":               [],
-    ".jshintrc":                [],
+//  ".jshintrc":                [],
+    ".eslintrc":                [],
+    ".eslintignore":            [],
     ".npmignore":               [],
     ".travis.yml":              [true, "MODULE_travis.yml"],
     "index.js":                 [true, "MODULE_index.js"],

--- a/test/template/browser.html
+++ b/test/template/browser.html
@@ -2,6 +2,8 @@
 <meta name="viewport" content="width=device-width, user-scalable=no">
 <meta charset="utf-8"></head><body>
 
+<script src="../lib/WebModuleGlobal.js"></script>
+
 __MODULES__
 __WMTOOLS__
 __SOURCES__

--- a/test/template/node.js
+++ b/test/template/node.js
@@ -1,5 +1,7 @@
 // REPOSITORY_NAME test
 
+require("../lib/WebModuleGlobal.js");
+
 __MODULES__
 __WMTOOLS__
 __SOURCES__

--- a/test/template/nw.html
+++ b/test/template/nw.html
@@ -2,6 +2,8 @@
 <meta name="viewport" content="width=device-width, user-scalable=no">
 <meta charset="utf-8"></head><body>
 
+<script src="../lib/WebModuleGlobal.js"></script>
+
 __MODULES__
 __WMTOOLS__
 __SOURCES__

--- a/test/template/worker.js
+++ b/test/template/worker.js
@@ -11,6 +11,8 @@ onmessage = function(event) {
         self.console.error = function() {};
     }
 
+    importScripts("../lib/WebModuleGlobal.js");
+
     __MODULES__
     __WMTOOLS__
     __SOURCES__


### PR DESCRIPTION
- use eslint (jshint does not use).
    - add .eslintignore
    - add .eslintrc
    - change run-script (scripts.hint = "eslint lib/*.js")
- add lib/WebModuleGlobal.js
    - add var GLOBAL
    - add var IN_NODE_OR_NW
    - add var IN_BROWSER
    - add var IN_WORKER
    - add var IN_NODE
    - add var IN_NW
    - add class WebModules
    - add var modules = new WebModule();
- use GLOBAL keyword
    - hide WebModule old idiom. (global = ((this || 0).self || global))
- add { "dependencies": { "uupaa.hash.js": "" }} to package.json